### PR TITLE
Fix #10: Sanitize GitHub token from git clone command lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 A lightweight Telegram bot that monitors GitHub issues, estimates difficulty/urgency, suggests what to work on, and can autonomously work on issues using Claude Code.
 
 <!-- BEGIN LINE COUNT -->
-📏 Core bot in **1171 lines** of Python (run `bash core_lines.sh` to verify)
+📏 Core bot in **1191 lines** of Python (run `bash core_lines.sh` to verify)
 <!-- END LINE COUNT -->
 
 ## Quick Start

--- a/minbot/github.py
+++ b/minbot/github.py
@@ -1,7 +1,9 @@
 """GitHub operations via PyGithub + git CLI."""
 
 import os
+import stat
 import subprocess
+import tempfile
 from github import Github
 
 _client: Github | None = None
@@ -162,6 +164,27 @@ def add_pr_comment(repo: str, number: int, body: str) -> None:
     _get_repo(repo).get_issue(number).create_comment(body)
 
 
+def _git_clone_with_token(repo: str, path: str) -> None:
+    """Clone using GIT_ASKPASS to avoid embedding the token in the command line."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+        f.write("#!/bin/sh\n"
+                "case \"$1\" in\n"
+                "  *Username*) echo x-access-token;;\n"
+                f"  *Password*) echo \"$GIT_TOKEN\";;\n"
+                "esac\n")
+        askpass = f.name
+    os.chmod(askpass, stat.S_IRWXU)
+    try:
+        env = {**os.environ, "GIT_ASKPASS": askpass,
+               "GIT_TERMINAL_PROMPT": "0", "GIT_TOKEN": _token}
+        subprocess.run(
+            ["git", "clone", f"https://github.com/{repo}.git", path],
+            check=True, capture_output=True, env=env,
+        )
+    finally:
+        os.unlink(askpass)
+
+
 def clone_repo(repo: str, path: str) -> None:
     """Clone a repo, or if already cloned, checkout main and pull."""
     if os.path.exists(os.path.join(path, ".git")):
@@ -180,7 +203,4 @@ def clone_repo(repo: str, path: str) -> None:
         )
     else:
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        subprocess.run(
-            ["git", "clone", f"https://x-access-token:{_token}@github.com/{repo}.git", path],
-            check=True, capture_output=True,
-        )
+        _git_clone_with_token(repo, path)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -117,7 +117,13 @@ def test_clone_repo_pulls_if_exists(mock_exists, mock_run):
 @patch("subprocess.run")
 @patch("os.path.exists", return_value=False)
 def test_clone_repo_clones_if_new(mock_exists, mock_run):
+    _setup_client()
     mock_run.return_value = MagicMock(returncode=0)
-    github.clone_repo("owner/repo", "/tmp/repo")
+    with patch("tempfile.NamedTemporaryFile", MagicMock()), \
+         patch("os.chmod"), \
+         patch("os.unlink"):
+        github.clone_repo("owner/repo", "/tmp/repo")
     args = mock_run.call_args[0][0]
     assert "clone" in args
+    # Token must NOT appear in the command-line arguments
+    assert all("fake-token" not in str(a) for a in args)


### PR DESCRIPTION
Closes #10

## Issue

**Sanitize GitHub token from git clone command lines**

In github.py, clone_repo() embeds the GitHub token directly in the git clone URL: `https://x-access-token:{_token}@github.com/...`. This exposes the token in process listings (ps aux), shell history, and any logs that capture subprocess arguments.

Suggested fix: Use git credential helpers or pass credentials via GIT_ASKPASS environment variable instead of embedding them in the URL. For example, set the token via the subprocess `env` parameter using GIT_ASKPASS pointing to a helper script, or us

## Changes

Done. Here's what was changed:

**`minbot/github.py`**: Replaced the inline token in the `git clone` URL with a `GIT_ASKPASS`-based approach:
- New `_git_clone_with_token()` helper creates a temporary shell script that returns `x-access-token` for username prompts and reads the token from the `GIT_TOKEN` env var for password prompts
- The token is passed via the subprocess `env` parameter (not visible in `ps aux` or logs)
- The clone URL is now a plain `https://github.com/{repo}.git` with no embedded credentials
- The temp script is cleaned up in a `finally` block

**`tests/test_github.py`**: Updated `test_clone_repo_clones_if_new` to mock the new tempfile/chmod/unlink calls and assert the token doesn't appear in command-line arguments.

---
Automated by [minbot](https://github.com/ChicagoHAI/minbot) using Claude Code.