### PR TITLE
Fix #12: Restrict file permissions on config.json containing secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 A lightweight Telegram bot that monitors GitHub issues, estimates difficulty/urgency, suggests what to work on, and can autonomously work on issues using Claude Code.
 
 <!-- BEGIN LINE COUNT -->
-📏 Core bot in **1171 lines** of Python (run `bash core_lines.sh` to verify)
+📏 Core bot in **1188 lines** of Python (run `bash core_lines.sh` to verify)
 <!-- END LINE COUNT -->
 
 ## Quick Start

--- a/minbot/config.py
+++ b/minbot/config.py
@@ -1,4 +1,7 @@
+import contextlib
 import json
+import os
+import tempfile
 from pathlib import Path
 from pydantic import BaseModel
 
@@ -23,4 +26,18 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
 
 def save_config(config: Config, path: Path = CONFIG_PATH) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(config.model_dump_json(indent=2))
+    os.chmod(path.parent, 0o700)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    closed = False
+    try:
+        os.write(fd, config.model_dump_json(indent=2).encode())
+        os.fchmod(fd, 0o600)
+        os.close(fd)
+        closed = True
+        os.rename(tmp, path)
+    except BaseException:
+        if not closed:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
+        raise


### PR DESCRIPTION
Closes #12

## Issue

**Restrict file permissions on config.json containing secrets**

In config.py, save_config() writes the configuration file (which contains github_token and optionally anthropic_api_key) using Path.write_text() with default permissions (typically 0644, world-readable). The parent directory is also created with default permissions.

Suggested fix: Use a temporary file + atomic rename pattern, and explicitly set file permissions to 0o600 (owner-read/write only) after writing. Set directory permissions to 0o700. This prevents other users on the system from readin

## Changes

Done. Here's what was changed in `minbot/config.py`:

- **Directory permissions**: `os.chmod(path.parent, 0o700)` — owner-only access to the config directory
- **File permissions**: `os.fchmod(fd, 0o600)` — owner-read/write only on the config file
- **Atomic write**: Uses `tempfile.mkstemp()` + `os.rename()` so the config file is never left in a partial state
- **Error handling**: Cleans up the temp file on failure

All 32 tests pass. Branch `issue-12` has been pushed.

---
Automated by [minbot](https://github.com/ChicagoHAI/minbot) using Claude Code.